### PR TITLE
Adding Alienware aw1022 in to the driver

### DIFF
--- a/r8152/src/50-usb-realtek-net.rules
+++ b/r8152/src/50-usb-realtek-net.rules
@@ -43,4 +43,7 @@ ATTR{idVendor}=="0955", ATTR{idProduct}=="09ff", ATTR{bConfigurationValue}!="$en
 # LINKSYS
 ATTR{idVendor}=="13b1", ATTR{idProduct}=="0041", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
 
+# Dell
+ATTRS{idVendor}=="413c", ATTRS{idProduct}=="b097", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+
 LABEL="usb_realtek_net_end"


### PR DESCRIPTION
Last time I was in the https://forums.unraid.net/topic/141349-plugin-realtek-r8125-r8168-and-r81526-drivers/page/2/#comment-1304553, since then I see the driver has not been add any other device. So I'm here trying to add one for who had aw1022 usb-lan card.